### PR TITLE
Run problemcheck after importing, add flag to skip check

### DIFF
--- a/FFXIV_TexTools_CLI/Arguments.cs
+++ b/FFXIV_TexTools_CLI/Arguments.cs
@@ -81,7 +81,7 @@ Available arguments:
                         case "custom":
                             customImport = true;
                             continue;
-                        case "np":
+                        case "npc":
                         case "noproblemcheck":
                             skipProblemCheck = true;
                             continue;

--- a/FFXIV_TexTools_CLI/Arguments.cs
+++ b/FFXIV_TexTools_CLI/Arguments.cs
@@ -34,7 +34,7 @@ Available arguments:
   -b, --backupdirectory    Full path to directory with your index backups
   -t, --ttmp               Full path to .ttmp(2) file (mods import only)
   -C, --custom             Use a modpack's config file to selectively import mods from the pack (modpack import only)
-  -np, --noproblemcheck    Skip the problem check after importing a modpack";
+  -npc, --noproblemcheck   Skip the problem check after importing a modpack";
             string ttmpPath = "";
             bool customImport = false;
             bool skipProblemCheck = false;

--- a/FFXIV_TexTools_CLI/Arguments.cs
+++ b/FFXIV_TexTools_CLI/Arguments.cs
@@ -24,7 +24,7 @@ namespace FFXIV_TexTools_CLI.Commandline
   mods refresh, mr         Enable/disable mods as specified in modlist.cfg
   backup, b                Backup clean index files for use in resetting the game
   reset, r                 Reset game to clean state
-  problemcheck, p          Check if there are any problems with the game, mod or backup files
+  problemcheck, pc         Check if there are any problems with the game, mod or backup files
   version, v               Display current application and game version
   help, h                  Display this text
 
@@ -33,9 +33,11 @@ Available arguments:
   -c, --configdirectory    Full path to directory where FFXIV.cfg and character data is saved, including 'FINAL FANTASY XIV - A Realm Reborn'
   -b, --backupdirectory    Full path to directory with your index backups
   -t, --ttmp               Full path to .ttmp(2) file (mods import only)
-  -C, --custom             Use a modpack's config file to selectively import mods from the pack (modpack import only)";
+  -C, --custom             Use a modpack's config file to selectively import mods from the pack (modpack import only)
+  -np, --noproblemcheck    Skip the problem check after importing a modpack";
             string ttmpPath = "";
             bool customImport = false;
+            bool skipProblemCheck = false;
             if (args.Length == 0)
             {
                 main.PrintMessage(helpText);
@@ -79,6 +81,10 @@ Available arguments:
                         case "custom":
                             customImport = true;
                             continue;
+                        case "np":
+                        case "noproblemcheck":
+                            skipProblemCheck = true;
+                            continue;
                         default:
                             main.PrintMessage($"Unknown argument {arg}", 3);
                             continue;
@@ -102,7 +108,7 @@ Available arguments:
                     if (PreviouslyModifiedGame())
                         return;
                     if (MainClass._gameDirectory != null)
-                        main.ImportModpackHandler(new DirectoryInfo(ttmpPath), customImport);
+                        main.ImportModpackHandler(new DirectoryInfo(ttmpPath), customImport, skipProblemCheck);
                     else
                         main.PrintMessage("Importing requires having your game directory set either through the config file or with -g specified", 2);
                     break;
@@ -176,7 +182,9 @@ Available arguments:
                         main.PrintMessage("Resetting game files requires having both your game and backup directories set through the config file or with -g and -b specified", 2);
                     break;
                 case "problemcheck":
-                case "p":
+                case "pc":
+                    if (PreviouslyModifiedGame())
+                        return;
                     if (MainClass._gameDirectory != null && MainClass._backupDirectory != null && MainClass._configDirectory != null)
                         main.ProblemChecker();
                     else

--- a/FFXIV_TexTools_CLI/Program.cs
+++ b/FFXIV_TexTools_CLI/Program.cs
@@ -154,7 +154,7 @@ namespace FFXIV_TexTools_CLI
         }
 
         #region Importing Functions
-        public void ImportModpackHandler(DirectoryInfo ttmpPath, bool customImport)
+        public void ImportModpackHandler(DirectoryInfo ttmpPath, bool customImport, bool skipProblemCheck)
         {
             var importError = false;
             try
@@ -202,7 +202,8 @@ namespace FFXIV_TexTools_CLI
                     return;
                 }
             }
-
+            if (!skipProblemCheck)
+                ProblemChecker();
             return;
         }
 
@@ -909,11 +910,16 @@ namespace FFXIV_TexTools_CLI
                 }
             }
             else
-                PrintMessage("No entries found in the modlist", 3);
+                PrintMessage("No entries found in the modlist, skipping", 3);
         }
 
         void CheckLoD()
         {
+            if (_configDirectory == null)
+            {
+                PrintMessage("No config directory specified, skipping", 3);
+                return;
+            }
             var problem = false;
             var DX11 = false;
             string ffxivCfg = Path.Combine(_configDirectory.FullName, "FFXIV.cfg");

--- a/FFXIV_TexTools_CLI/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools_CLI/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("0.3.5.*")]
+[assembly: AssemblyVersion("0.3.7.*")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
Catch config directory not being set in the problem checker. A user importing a modpack without skipping the problem check may not have their config directory set, which would result in a NullReferenceException on CheckLoD.
Make error message from CheckMods more descriptive